### PR TITLE
Replace login_or_token arg with auth arg

### DIFF
--- a/mkdocs_git_snippet/plugin.py
+++ b/mkdocs_git_snippet/plugin.py
@@ -3,7 +3,7 @@ import os
 import mkdocs
 from mkdocs.plugins import BasePlugin
 from jinja2 import Template
-from github import Github, GithubObject
+from github import Auth, Github, GithubObject
 
 from mkdocs_git_snippet.util import (
     skip_page,
@@ -20,7 +20,7 @@ class GitSnippetPlugin(BasePlugin):
     page = None
 
     def _git_snippet(self, repository: str, file: str, ref: str, section: str) -> str:
-        g = Github(os.getenv("GITHUB_TOKEN"))
+        g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
         repo = g.get_repo(repository)
         f = repo.get_contents(file, ref=ref)
         content = f.decoded_content.decode("utf-8")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs
-pygithub
+pygithub>=1.59.0
 parse


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

# WHY

Starting [pygithub 1.59.0](https://github.com/PyGithub/PyGithub/releases/tag/v1.59.0), `login_or_token` was deprecated and replaced by a single `auth` arg.
The following message is shown when we run `mkdocs build`.

```
INFO     -  DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
              File "/Users/USERNAME/.local/share/virtualenvs/VENVDIR/lib/python3.8/site-packages/mkdocs_git_snippet/plugin.py", line 23, in
            _git_snippet
                g = Github(os.getenv("GITHUB_TOKEN"))
              File "/Users/USERNAME/.local/share/virtualenvs/VENVDIR/lib/python3.8/site-packages/github/MainClass.py", line 145, in __init__
                warnings.warn(
```

# WHAT

- Replaced `login_or_token` arg with `auth` arg.
- Updated requirements.txt to use pygithub>=1.59.0 as `auth` arg is not available with older versions.

Could you release the next version so I can use it in my docs?
