### PR TITLE
Bump version: 0.1.1 → 0.1.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = False
 serialize = {major}.{minor}.{patch}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.command.upload import upload as upload_orig
 from setuptools import find_packages, setup
 from typing import List
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 
 def generate_install_requires() -> List[str]:


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

To release a new version which includes #8.
As there is no new feature, 0.1.2 (not 0.2.0) would be fine.
